### PR TITLE
Add our babel5 rc file

### DIFF
--- a/.babel5rc
+++ b/.babel5rc
@@ -1,0 +1,19 @@
+{
+  "whitelist": [
+    "es3.memberExpressionLiterals",
+    "es3.propertyLiterals",
+    "es6.arrowFunctions",
+    "es6.blockScoping",
+    "es6.classes",
+    "es6.constants",
+    "es6.destructuring",
+    "es6.modules",
+    "es6.parameters",
+    "es6.properties.computed",
+    "es6.properties.shorthand",
+    "es6.spread",
+    "es6.templateLiterals",
+    "es6.regex.unicode",
+    "react"
+  ]
+}


### PR DESCRIPTION
For our projects that depend on babel5 so we can reference this babelrc instead of keeping the whitelist elsewhere.

Should we export this as as JS object as well so we can include it with other config?

to @ljharb @justjake 