### PR TITLE
Add async-to-promises Babel plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   ],
   plugins: [
     [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
+    require('babel-plugin-async-to-promises'),
     require('babel-plugin-transform-es3-member-expression-literals'),
     require('babel-plugin-transform-es3-property-literals'),
     require('babel-plugin-transform-jscript'),

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "babel-plugin-async-to-promises": "^1.0.4",
     "babel-plugin-transform-es2015-template-literals": "^6.5.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
     "babel-plugin-transform-es3-property-literals": "^6.5.0",
-    "babel-plugin-transform-jscript": "^6.5.0",
     "babel-plugin-transform-exponentiation-operator": "^6.5.0",
+    "babel-plugin-transform-jscript": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0"
   }


### PR DESCRIPTION
This plugin claims to enable async/await without generators.

https://github.com/marten-de-vries/kneden
