### PR TITLE
Replace babel-preset-es2015 with babel-preset-es2015-without-strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    require('babel-preset-es2015'),
+    require('babel-preset-es2015-without-strict'),
     require('babel-preset-react'),
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "babel-plugin-transform-es2015-template-literals": "^6.5.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
     "babel-plugin-transform-es3-property-literals": "^6.5.0",
-    "babel-plugin-transform-jscript": "^6.5.0",
     "babel-plugin-transform-exponentiation-operator": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-plugin-transform-jscript": "^6.5.0",
+    "babel-preset-es2015-without-strict": "^0.0.2",
     "babel-preset-react": "^6.5.0"
   }
 }


### PR DESCRIPTION
The 2015 Babel preset prepends `'use strict';` to every file. According
to [this issue](https://phabricator.babeljs.io/T6660):

> ES6 module code, which Babel expects by default, is automatically
> Strict Mode according to the ES6 spec, hence es2015 includes it by
> default.

However, in practice, this breaks a bunch of things for us, such as
vendored code that violates strict mode and script tags in HTML returned
by AJAX requests violating our CSP. I made an effort to fix a lot of
these problems, but the probability of there being many more that I
didn't find is too high that I cannot safely continue moving forward on
this path.

Thankfully, the transform that does this
(babel-plugin-transform-es2015-modules-commonjs) accepts an option do
disable it. If I read the code correctly, with the `strict: false`
option, it will only add `'use strict';` if the file has exports.

https://github.com/babel/babel/blob/2607f35b/packages/babel-plugin-transform-es2015-modules-commonjs/src/index.js#L437

To make more of our code work with this transform, I am swapping out the
babel-preset-es2015 for babel-preset-es2015-without-strict, which is the
same as the 2015 preset but with the `strict: false` option set. I
considered just inlining the preset, but this is a smaller change and
simple enough. If we end up with more deviations, we can consider
inlining it at that time, but I think having a little extra friction for
that will do us some good.