### PR TITLE
Conditionally use es2015 preset when passed options with modules: false.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,24 @@
-module.exports = {
-  presets: [
-    require('babel-preset-es2015-without-strict'),
-    require('babel-preset-react'),
-  ],
-  plugins: [
-    [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
-    require('babel-plugin-transform-es3-member-expression-literals'),
-    require('babel-plugin-transform-es3-property-literals'),
-    require('babel-plugin-transform-jscript'),
-    require('babel-plugin-transform-exponentiation-operator'),
-    require('babel-plugin-syntax-trailing-function-commas'),
-    [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
-  ],
-};
+module.exports = function(context, options) {
+  var es2015preset;
+  if (options && options.modules === false) {
+    es2015preset = ['es2015', { modules: false }];
+  } else {
+    es2015preset = 'es2015-without-strict';
+  }
+
+  return {
+    presets: [
+      es2015preset,
+      'react',
+    ],
+    plugins: [
+      ['transform-es2015-template-literals', { spec: true }],
+      'transform-es3-member-expression-literals',
+      'transform-es3-property-literals',
+      'transform-jscript',
+      'transform-exponentiation-operator',
+      'syntax-trailing-function-commas',
+      ['transform-object-rest-spread', { useBuiltIns: true }],
+    ],
+  };
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-transform-exponentiation-operator": "^6.8.0",
     "babel-plugin-transform-jscript": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
+    "babel-preset-es2015": "^6.22.0",
     "babel-preset-es2015-without-strict": "^0.0.4",
     "babel-preset-react": "^6.16.0"
   }


### PR DESCRIPTION
@ljharb @goatslacker 

Passing the option `modules: false` defeats the purpose of the `without-strict`
preset, as strict is an option being applied to a plugin that `modules: false`
removes.  This change will enable users to transform `import` and `import()`
statements with webpack2 instead of babel, and will enable tree shaking.

Just a note on the es2015 string... it appears that providing options to presets
using `require` doesn't work. It logs a bunch of these error messages:
```
[Error: Options {"modules":false} passed to a preset which does not accept options. (While processing preset: "~/repos/babel-preset-airbnb/index.js")]
```