### PR TITLE
Reenable native modules.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,5 +5,9 @@
 
   "rules": {
     "global-require": 0,
-  }
+    "strict": ["error", "global"],
+  },
+  "parserOptions": {
+    "sourceType": "script",
+  },
 }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,25 @@
-module.exports = {
-  presets: [
-    require('babel-preset-es2015-without-strict'),
-    require('babel-preset-react'),
-  ],
-  plugins: [
-    [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
-    require('babel-plugin-transform-es3-member-expression-literals'),
-    require('babel-plugin-transform-es3-property-literals'),
-    require('babel-plugin-transform-jscript'),
-    require('babel-plugin-transform-exponentiation-operator'),
-    require('babel-plugin-syntax-trailing-function-commas'),
-    [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
-  ],
+'use strict';
+
+module.exports = (context, options) => {
+  let preset;
+  if (options && options.modules === false) {
+    preset = require('babel-preset-es2015').buildPreset(null, { modules: false });
+  } else {
+    preset = require('babel-preset-es2015-without-strict');
+  }
+  return {
+    presets: [
+      preset,
+      require('babel-preset-react'),
+    ],
+    plugins: [
+      [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
+      require('babel-plugin-transform-es3-member-expression-literals'),
+      require('babel-plugin-transform-es3-property-literals'),
+      require('babel-plugin-transform-jscript'),
+      require('babel-plugin-transform-exponentiation-operator'),
+      require('babel-plugin-syntax-trailing-function-commas'),
+      [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
+    ],
+  };
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-transform-exponentiation-operator": "^6.8.0",
     "babel-plugin-transform-jscript": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
+    "babel-preset-es2015": "^6.22.0",
     "babel-preset-es2015-without-strict": "^0.0.4",
     "babel-preset-react": "^6.16.0"
   },


### PR DESCRIPTION
to: @ljharb Second attempt.
cc: @kesne

This is the second attempt at enabling native modules with the airbnb babel
preset.The first attempt used strings instead of require statements, and
broke plugin resolution when babel-preset-airbnb was a sub dependency.

Passing the option `modules: false` defeats the purpose of the `without-strict`
preset, as strict is an option being applied to a plugin that `modules: false`
removes.  This change will enable users to transform `import` and `import()`
statements with webpack2 instead of babel, and will enable tree shaking.