### PR TITLE
Adding development plugins and using builtins for jsx spread

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,53 @@
 'use strict';
 
 module.exports = function buildAirbnbPreset(context, options) {
+  // This is similar to how `env` works in Babel:
+  // https://babeljs.io/docs/usage/babelrc/#env-option
+  // We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
+  // https://github.com/babel/babel/issues/4539
+  // https://github.com/facebookincubator/create-react-app/issues/720
+  // It’s also nice that we can enforce `NODE_ENV` being specified.
+  var env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  if (env !== 'development' && env !== 'test' && env !== 'production') {
+    throw new Error(
+      'Using `babel-preset-airbnb` requires that you specify `NODE_ENV` or '+
+      '`BABEL_ENV` environment variables. Valid values are "development", ' +
+      '"test", and "production". Instead, received: ' + JSON.stringify(env) + '.'
+    );
+  }
+
+  var allPlugins = [
+    [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
+    require('babel-plugin-transform-es3-member-expression-literals'),
+    require('babel-plugin-transform-es3-property-literals'),
+    require('babel-plugin-transform-jscript'),
+    require('babel-plugin-transform-exponentiation-operator'),
+    require('babel-plugin-syntax-trailing-function-commas'),
+    [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
+    [require('babel-plugin-transform-react-jsx'), { useBuiltIns: true }],
+  ];
   var preset; // eslint-disable-line no-var
+
   if (options && options.modules === false) {
     preset = require('babel-preset-es2015').buildPreset(null, { modules: false });
   } else {
     preset = require('babel-preset-es2015-without-strict');
   }
+
+  if (env === 'development') {
+    allPlugins.push(
+      // Adds component stack to warning messages
+      require.resolve('babel-plugin-transform-react-jsx-source'),
+      // Adds __self attribute to JSX which React will use for some warnings
+      require.resolve('babel-plugin-transform-react-jsx-self')
+    );
+  }
+
   return {
     presets: [
       preset,
       require('babel-preset-react'),
     ],
-    plugins: [
-      [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
-      require('babel-plugin-transform-es3-member-expression-literals'),
-      require('babel-plugin-transform-es3-property-literals'),
-      require('babel-plugin-transform-jscript'),
-      require('babel-plugin-transform-exponentiation-operator'),
-      require('babel-plugin-syntax-trailing-function-commas'),
-      [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
-    ],
+    plugins: allPlugins,
   };
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-var, prefer-template, comma-dangle */
+
 'use strict';
 
 module.exports = function buildAirbnbPreset(context, options) {
@@ -7,16 +9,10 @@ module.exports = function buildAirbnbPreset(context, options) {
   // https://github.com/babel/babel/issues/4539
   // https://github.com/facebookincubator/create-react-app/issues/720
   // It’s also nice that we can enforce `NODE_ENV` being specified.
-  var env = process.env.BABEL_ENV || process.env.NODE_ENV;
-  if (env !== 'development' && env !== 'test' && env !== 'production') {
-    throw new Error(
-      'Using `babel-preset-airbnb` requires that you specify `NODE_ENV` or '+
-      '`BABEL_ENV` environment variables. Valid values are "development", ' +
-      '"test", and "production". Instead, received: ' + JSON.stringify(env) + '.'
-    );
-  }
+  var env = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
 
   var allPlugins = [
+    [require('babel-plugin-transform-es2015-block-scoping'), { throwIfClosureRequired: true }],
     [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
     require('babel-plugin-transform-es3-member-expression-literals'),
     require('babel-plugin-transform-es3-property-literals'),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "babel-plugin-syntax-trailing-function-commas": "^6.13.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
     "babel-plugin-transform-es2015-template-literals": "^6.8.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.8.0",
     "babel-plugin-transform-es3-property-literals": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "babel-plugin-transform-exponentiation-operator": "^6.8.0",
     "babel-plugin-transform-jscript": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
+    "babel-plugin-transform-react-jsx": "^6.23.0",
+    "babel-plugin-transform-react-jsx-self": "^6.22.0",
+    "babel-plugin-transform-react-jsx-source": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-es2015-without-strict": "^0.0.4",
     "babel-preset-react": "^6.16.0"


### PR DESCRIPTION
Taking some inspiration from the `create-react-app` configuration, I added an env check, and added two development plugins that make React messages a lot nicer looking and more helpful. I also added `tranform-react-jsx` to set `useBuiltIns` to true, so that we get `Object.assign` emitted when spreading in JSX.

If this lands, it'll need to be a major release because of the new `NODE_ENV` requirement.