### PR TITLE
Creates a Node@6.10.2 target for transpiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,12 @@ module.exports = function buildAirbnbPreset(context, options) {
   var preset; // eslint-disable-line no-var
   if (options && options.modules === false) {
     preset = require('babel-preset-es2015').buildPreset(null, { modules: false });
+  } else if (options && options.node === true) {
+    preset = require('babel-preset-env').default(null, {
+      targets: {
+        node: '6.10.2',
+      },
+    });
   } else {
     preset = require('babel-preset-es2015-without-strict');
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-plugin-transform-exponentiation-operator": "^6.24.1",
     "babel-plugin-transform-jscript": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-preset-env": "^1.5.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2015-without-strict": "^0.0.4",
     "babel-preset-react": "^6.24.1"


### PR DESCRIPTION
When setting the `node` option to true it'll use `babel-preset-env` to
target a specific version of Node which means less transpiling and it'll
use the native ES-next features in v8.