### PR TITLE
Switches to use babel-preset-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,50 @@ require("babel-core").transform("code", {
   presets: ["airbnb"]
 });
 ```
+
+### Targeting Environments
+
+This module uses babel-preset-env to target specific environments.
+
+Please refer to [babel-preset-env#targets](https://github.com/babel/babel-preset-env#targets) for a list of available options.
+
+For a list of browsers please see [browserlist](https://github.com/ai/browserslist).
+
+You may override our default list of targets by providing your own `targets` key.
+
+```json
+{
+  "presets": [["airbnb", {
+    "targets": {
+      "chrome": 50,
+      "explorer": 11,
+      "firefox": 45
+    }
+  }]]
+}
+```
+
+The following transpiles only for Node v6.
+
+```json
+{
+  "presets": [["airbnb", {
+    "targets": {
+      "node": 6
+    }
+  }]]
+}
+```
+
+If you wish, you can also inherit our default list of browsers and extend them using `additionalTargets`.
+
+```json
+{
+  "presets": [["airbnb", {
+    "additionalTargets": {
+      "chrome": 42,
+      "explorer": 8
+    }
+  }]]
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,25 +1,51 @@
 'use strict';
 
+const modules = [require('babel-plugin-transform-es2015-modules-commonjs'), {
+  strict: false,
+}];
+
+const defaultTargets = {
+  android: 30,
+  chrome: 35,
+  edge: 14,
+  explorer: 9,
+  firefox: 52,
+  safari: 8,
+  ucandroid: 1,
+};
+
+function buildTargets(options) {
+  return Object.assign({}, defaultTargets, options.additionalTargets);
+}
+
 module.exports = function buildAirbnbPreset(context, options) {
-  var preset; // eslint-disable-line no-var
-  if (options && options.modules === false) {
-    preset = require('babel-preset-es2015').buildPreset(null, { modules: false });
-  } else {
-    preset = require('babel-preset-es2015-without-strict');
-  }
+  const targets = (options && options.targets) || buildTargets(options);
+
   return {
     presets: [
-      preset,
+      require('babel-preset-env').default(null, {
+        debug: true,
+        exclude: [
+          'transform-async-to-generator',
+          'transform-es2015-template-literals',
+          'transform-regenerator',
+        ],
+        modules: false,
+        targets,
+      }),
       require('babel-preset-react'),
     ],
     plugins: [
-      [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
+      options && options.modules === false ? null : modules,
+      [require('babel-plugin-transform-es2015-template-literals'), {
+        spec: true,
+      }],
       require('babel-plugin-transform-es3-member-expression-literals'),
       require('babel-plugin-transform-es3-property-literals'),
       require('babel-plugin-transform-jscript'),
-      require('babel-plugin-transform-exponentiation-operator'),
-      require('babel-plugin-syntax-trailing-function-commas'),
-      [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
-    ],
+      [require('babel-plugin-transform-object-rest-spread'), {
+        useBuiltIns: true,
+      }],
+    ].filter(Boolean),
   };
 };

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "license": "Apache-2.0",
   "dependencies": {
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-plugin-transform-exponentiation-operator": "^6.24.1",
     "babel-plugin-transform-jscript": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2015-without-strict": "^0.0.4",
+    "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Babel7 is set to deprecate the ES2015 preset and the new recommended
approach is to use babel-preset-env which also lets you fine tune the
transforms specific to the environments the code will be run on. This
commit moves our implementation to use babel-preset-env as well as lists
a few browsers we support.

Fixes #10 

I tested this by checking in files that were transpiled with `master`'s configuration and then switching over to `babel-preset-env` and re-running the transpile step. `git diff` was empty.