### PR TITLE
Creates a Node target for transpiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,42 @@
 'use strict';
 
 module.exports = function buildAirbnbPreset(context, options) {
-  var preset; // eslint-disable-line no-var
-  if (options && options.modules === false) {
-    preset = require('babel-preset-es2015').buildPreset(null, { modules: false });
-  } else {
-    preset = require('babel-preset-es2015-without-strict');
-  }
   return {
     presets: [
-      preset,
+      require('babel-preset-env').default(null, {
+        debug: true,
+        exclude: [
+          'transform-async-to-generator',
+          'transform-es2015-template-literals',
+          'transform-regenerator',
+        ],
+        modules: false,
+        targets: {
+          browsers: [
+            'Chrome >= 35',
+            'Explorer >= 9',
+            'Firefox >= 52',
+            'Safari >= 8',
+          ],
+        },
+      }),
       require('babel-preset-react'),
     ],
     plugins: [
-      [require('babel-plugin-transform-es2015-template-literals'), { spec: true }],
+      options && options.modules === false ? null : (
+        [require("babel-plugin-transform-es2015-modules-commonjs"), {
+          strict: false,
+        }]
+      ),
+      [require('babel-plugin-transform-es2015-template-literals'), {
+        spec: true,
+      }],
       require('babel-plugin-transform-es3-member-expression-literals'),
       require('babel-plugin-transform-es3-property-literals'),
       require('babel-plugin-transform-jscript'),
-      require('babel-plugin-transform-exponentiation-operator'),
-      require('babel-plugin-syntax-trailing-function-commas'),
-      [require('babel-plugin-transform-object-rest-spread'), { useBuiltIns: true }],
-    ],
+      [require('babel-plugin-transform-object-rest-spread'), {
+        useBuiltIns: true,
+      }],
+    ].filter(Boolean),
   };
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,23 @@
 'use strict';
 
+const browsers = [
+  'Chrome >= 35',
+  'Explorer >= 9',
+  'Firefox >= 52',
+  'Safari >= 8',
+];
+
+function setNodeVersion(version) {
+  if (typeof version !== 'string' && version !== true) {
+    throw new TypeError('`node` must either be `true` or a string');
+  }
+  return version === true ? '6.10.2' : version;
+}
+
 module.exports = function buildAirbnbPreset(context, options) {
+  const targets = options.node
+    ? { node: setNodeVersion(options.node) }
+    : { browsers };
   return {
     presets: [
       require('babel-preset-env').default(null, {
@@ -11,14 +28,7 @@ module.exports = function buildAirbnbPreset(context, options) {
           'transform-regenerator',
         ],
         modules: false,
-        targets: {
-          browsers: [
-            'Chrome >= 35',
-            'Explorer >= 9',
-            'Firefox >= 52',
-            'Safari >= 8',
-          ],
-        },
+        targets,
       }),
       require('babel-preset-react'),
     ],

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "license": "Apache-2.0",
   "dependencies": {
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-plugin-transform-exponentiation-operator": "^6.24.1",
     "babel-plugin-transform-jscript": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2015-without-strict": "^0.0.4",
+    "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.24.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When setting the `node` option to true it'll use `babel-preset-env` to
target a specific version of Node which means less transpiling and it'll
use the native ES-next features in v8.

Closes #12 
Depends on #13 