### PR TITLE
Fixes undefined options

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function buildTargets(options) {
 }
 
 module.exports = function buildAirbnbPreset(context, options) {
-  const targets = (options && options.targets) || buildTargets(options);
+  const targets = (options && options.targets) || buildTargets(options || {});
 
   return {
     presets: [


### PR DESCRIPTION
On [line 18](https://github.com/airbnb/babel-preset-airbnb/blob/146be3b5c051b99d32f69066dfd0679e3bcb0fcb/index.js#L18) we access `additionalTargets` of a presumed `options` object. This change ensures that options exists or is an object when passing it into the buildTargets function.