### PR TITLE
Setup lint and tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
   "root": true,
 
+  "ecmaVersion": 5,
+
   "extends": "airbnb-base",
 
   "rules": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 os:
  - linux
 node_js:
+  - "8"
+  - "6"
+  - "4"
+  - "0.12"
 before_install:
   - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ]; then npm install -g npm@1.3 ; elif [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then case "$(npm --version)" in 1.*) npm install -g npm@1.4.28 ;; 2.*) npm install -g npm@2 ;; esac ; fi'
   - 'if [ "${TRAVIS_NODE_VERSION%${TRAVIS_NODE_VERSION#[0-9]}}" = "0" ]; then npm install -g npm@4.5 ; elif [ "${TRAVIS_NODE_VERSION}" != "0.6" ] && [ "${TRAVIS_NODE_VERSION}" != "0.9" ]; then npm install -g npm; fi'

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function buildTargets(options) {
 }
 
 module.exports = function buildAirbnbPreset(context, options) {
-  var targets = (options && options.targets) || buildTargets(options || {});
+  var transpileTargets = (options && options.targets) ||
+    buildTargets(options || {});
 
   return {
     presets: [
@@ -33,7 +34,7 @@ module.exports = function buildAirbnbPreset(context, options) {
           'transform-regenerator',
         ],
         modules: false,
-        targets,
+        targets: transpileTargets,
       }),
       require('babel-preset-react'),
     ],


### PR DESCRIPTION
This PR 

* fixes the index.js file so that it runs on a pure ES5 env
* Adds `ecmaVersion` to .eslintrc so that we can lint against these in the future
* Adds specific node versions to our .travis file so that the tests run on travis and we can ensure tests pass before merging

