### PR TITLE
Turn off debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ module.exports = function buildAirbnbPreset(context, options) {
   return {
     presets: [
       require('babel-preset-env').default(null, {
-        debug: true,
         exclude: [
           'transform-async-to-generator',
           'transform-es2015-template-literals',


### PR DESCRIPTION
I started noticing a ton of random logging from `babel-preset-env` after updated the dependencies of an old project, and traced it down to a this line. I'm not too familiar with this preset, so I'm not sure if always-on debugging is a feature or a bug. In case it's an oversight, here's a quick PR fixing it (: