### PR TITLE
[New] set "strict" to true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var assign = require('object.assign');
 
 var modules = [require('babel-plugin-transform-es2015-modules-commonjs'), {
-  strict: false
+  strict: true
 }];
 
 var defaultTargets = {


### PR DESCRIPTION
This was disabled in https://github.com/airbnb/babel-preset-airbnb/commit/f011dd9a2febec4687cd08e3162196a836550b3e, because we still had lots of internal code that this might have broken.

I do not believe this is still true, so we should re-enable this.