### PR TITLE
Add React propTypes removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,20 @@ You may override our default debug option by providing your own `debug` key.
 
 ## React PropTypes removal
 
-This preset will remove propTypes using [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) with the following default options:
+This preset can be configured to remove propTypes using [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) with the following default options:
+
+
+To enable this transformation with the default options, set the `removePropTypes` option to `true`:
+
+```json
+{
+  "presets": [["airbnb", {
+    "removePropTypes": true
+  }]]
+}
+```
+
+The default options that will be used are:
 
 ```js
 {
@@ -109,18 +122,7 @@ This preset will remove propTypes using [babel-plugin-transform-react-remove-pro
 }
 ```
 
-To disable this transformation, use the `removePropTypes` option:
-
-```json
-{
-  "presets": [["airbnb", {
-    "removePropTypes": false
-  }]]
-}
-```
-
-Default options can be overridden using the `removePropTypes` option. These
-options will be shallow-merged with the defaults:
+Default options can be overridden using the `removePropTypes` option. These options will be shallow-merged with the defaults:
 
 ```json
 {
@@ -132,6 +134,4 @@ options will be shallow-merged with the defaults:
 }
 ```
 
-For example, if you are using this plugin in a deployable app, you might want to
-use the remove mode for your production build (and disable this transform
-entirely in development for optimal build speeds).
+For example, if you are using this plugin in a deployable app, you might want to use the remove mode for your production build (and disable this transform entirely in development for optimal build speeds).

--- a/README.md
+++ b/README.md
@@ -96,3 +96,42 @@ You may override our default debug option by providing your own `debug` key.
   }]]
 }
 ```
+
+## React PropTypes removal
+
+This preset will remove propTypes using [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) with the following default options:
+
+```js
+{
+  mode: 'wrap',
+  additionalLibraries: ['airbnb-prop-types'],
+  ignoreFilenames: ['node_modules'],
+}
+```
+
+To disable this transformation, use the `removePropTypes` option:
+
+```json
+{
+  "presets": [["airbnb", {
+    "removePropTypes": false
+  }]]
+}
+```
+
+Default options can be overridden using the `removePropTypes` option. These
+options will be shallow-merged with the defaults:
+
+```json
+{
+  "presets": [["airbnb", {
+    "removePropTypes": {
+      "mode": "remove"
+    }
+  }]]
+}
+```
+
+For example, if you are using this plugin in a deployable app, you might want to
+use the remove mode for your production build (and disable this transform
+entirely in development for optimal build speeds).

--- a/index.js
+++ b/index.js
@@ -41,11 +41,11 @@ module.exports = function buildAirbnbPreset(context, options) {
       require('babel-preset-react')
     ],
     plugins: [
-      options && options.removePropTypes === false ? null : ['babel-plugin-transform-react-remove-prop-types', assign({
+      options && !!options.removePropTypes ? ['babel-plugin-transform-react-remove-prop-types', assign({
         mode: 'wrap',
         additionalLibraries: ['airbnb-prop-types'],
         ignoreFilenames: ['node_modules']
-      }, options.removePropTypes)],
+      }, options.removePropTypes)] : null,
 
       options && options.modules === false ? null : modules,
       options && options.modules === false ? null : ['babel-plugin-transform-strict-mode', { strictMode: true }],

--- a/index.js
+++ b/index.js
@@ -41,6 +41,12 @@ module.exports = function buildAirbnbPreset(context, options) {
       require('babel-preset-react')
     ],
     plugins: [
+      options && options.removePropTypes === false ? null : ['babel-plugin-transform-react-remove-prop-types', assign({
+        mode: 'wrap',
+        additionalLibraries: ['airbnb-prop-types'],
+        ignoreFilenames: ['node_modules']
+      }, options.removePropTypes)],
+
       options && options.modules === false ? null : modules,
       options && options.modules === false ? null : ['babel-plugin-transform-strict-mode', { strictMode: true }],
       [require('babel-plugin-transform-es2015-template-literals'), {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-transform-exponentiation-operator": "^6.24.1",
     "babel-plugin-transform-jscript": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.15",
     "babel-plugin-transform-strict-mode": "^6.24.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
I originally started by adding this plugin to react-dates, but it seems
like we are going to want this in a lot of places, so it makes sense to
put it into our preset instead.

https://github.com/airbnb/react-dates/pull/1322

For the default options, I decided to go with "wrap" as the mode, since
we are likely to use this more frequently in packages that are published
and consumed by other packages and apps, which aren't very compatible
with the "remove" option.

In our apps where this is not a concern, we will want to override this
to use the "remove" option in production and likely disable this plugin
entirely in development for better build speeds.