### PR TITLE
Remove es3 plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,6 @@ module.exports = declare((api, options) => {
         spec: true,
       }],
       require('@babel/plugin-transform-property-mutators'),
-      require('@babel/plugin-transform-member-expression-literals'),
-      require('@babel/plugin-transform-property-literals'),
       require('@babel/plugin-transform-jscript'),
       [require('@babel/plugin-proposal-object-rest-spread'), {
         useBuiltIns: true,

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
     "@babel/plugin-transform-jscript": "^7.0.0",
-    "@babel/plugin-transform-member-expression-literals": "^7.0.0",
-    "@babel/plugin-transform-property-literals": "^7.0.0",
     "@babel/plugin-transform-property-mutators": "^7.0.0",
     "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/preset-env": "^7.0.0",


### PR DESCRIPTION
Remove `@babel/plugin-transform-member-expression-literals` and  `@babel/plugin-transform-property-literals` since they were added to support es3. 

cc. @goatslacker @ljharb 