### PR TITLE
Change assert version range from ^7.0.0-0 to ^7.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function buildTargets({ additionalTargets }) {
 
 module.exports = declare((api, options) => {
   // see docs about api at https://babeljs.io/docs/en/config-files#apicache
-  api.assertVersion(7);
+  api.assertVersion('^7.0.0');
 
   const {
     modules,


### PR DESCRIPTION
[`babel` will actually turn `api.assertVersion(7)` to `api.assertVersion('^7.0.0-0')`](https://github.com/babel/babel/blob/806e1334737f4fbf29615c04d227076b76d7f041/packages/babel-core/src/config/helpers/config-api.js#L67), but the version range set in `peerDependencies` is `^7.0.0`.