### PR TITLE
Remove babel-plugin-transform-jscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,15 @@ Default options can be overridden using the `removePropTypes` option. These opti
 ```
 
 For example, if you are using this plugin in a deployable app, you might want to use the remove mode for your production build (and disable this transform entirely in development for optimal build speeds).
+
+## JScript
+
+This preset uses a transform to protect against JScript bugs in older versions of Internet Explorer. If you'd like to disable this, set the `jscript` option to `false`:
+
+```json
+{
+  "presets": [["airbnb", {
+    "jscript": false,
+  }]]
+}
+```

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = declare((api, options) => {
     modules,
     targets = buildTargets(options),
     removePropTypes,
+    jscript = true,
   } = options;
 
   if (typeof modules !== 'undefined' && typeof modules !== 'boolean' && modules !== 'auto') {
@@ -62,6 +63,7 @@ module.exports = declare((api, options) => {
       require('@babel/plugin-transform-property-mutators'),
       require('@babel/plugin-transform-member-expression-literals'),
       require('@babel/plugin-transform-property-literals'),
+      jscript ? require('@babel/plugin-transform-jscript') : null,
       [require('@babel/plugin-proposal-object-rest-spread'), {
         useBuiltIns: true,
       }],

--- a/index.js
+++ b/index.js
@@ -62,7 +62,6 @@ module.exports = declare((api, options) => {
       require('@babel/plugin-transform-property-mutators'),
       require('@babel/plugin-transform-member-expression-literals'),
       require('@babel/plugin-transform-property-literals'),
-      require('@babel/plugin-transform-jscript'),
       [require('@babel/plugin-proposal-object-rest-spread'), {
         useBuiltIns: true,
       }],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+    "@babel/plugin-transform-jscript": "^7.0.0",
     "@babel/plugin-transform-member-expression-literals": "^7.0.0",
     "@babel/plugin-transform-property-literals": "^7.0.0",
     "@babel/plugin-transform-property-mutators": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-    "@babel/plugin-transform-jscript": "^7.0.0",
     "@babel/plugin-transform-member-expression-literals": "^7.0.0",
     "@babel/plugin-transform-property-literals": "^7.0.0",
     "@babel/plugin-transform-property-mutators": "^7.0.0",


### PR DESCRIPTION
This plugin is used to transform code to avoid some JScript bugs, which
only affect old versions of Internet Explorer that we no longer support.
By removing this, our compiled code will be smaller and run faster.

https://kangax.github.io/nfe/#jscript-bugs