### PR TITLE
Add looseClasses option to compile classes in loose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,17 @@ Default options can be overridden using the `removePropTypes` option. These opti
 ```
 
 For example, if you are using this plugin in a deployable app, you might want to use the remove mode for your production build (and disable this transform entirely in development for optimal build speeds).
+
+## Classes loose mode
+
+By default, this preset will compile classes in normal mode. This is safer, but comes with a bundle size and runtime overhead. To [compile classes in loose mode](https://babeljs.io/docs/en/babel-plugin-transform-classes#loose), set the `looseClasses` option to `true`:
+
+```json
+{
+  "presets": [["airbnb", {
+    "looseClasses": true,
+  }]]
+}
+```
+
+The [risks of enabling loose classes are outlined in the Babel docs](https://babeljs.io/docs/en/babel-plugin-transform-classes#loose).

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = declare((api, options) => {
     modules,
     targets = buildTargets(options),
     removePropTypes,
+    looseClasses = false,
   } = options;
 
   // jscript option is deprecated in favor of using the explorer target version
@@ -56,6 +57,10 @@ module.exports = declare((api, options) => {
       [require('@babel/preset-react'), { development }],
     ],
     plugins: [
+      looseClasses ? [require('@babel/plugin-transform-classes'), {
+        loose: true,
+      }] : null,
+
       removePropTypes ? [require('babel-plugin-transform-react-remove-prop-types'), Object.assign({
         mode: 'wrap',
         additionalLibraries: ['airbnb-prop-types'],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-classes": "^7.2.0",
     "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
     "@babel/plugin-transform-jscript": "^7.0.0",
     "@babel/plugin-transform-member-expression-literals": "^7.0.0",


### PR DESCRIPTION
Compiling classes in normal mode is safer, but it comes with a small
bundle size and runtime overhead. For consumers that don't want to make
this tradeoff, I am adding an option to disable this. Poking around
other large codebases and I have been unable to find any other company
not using loose mode for classes.

  https://babeljs.io/docs/en/babel-plugin-transform-classes#loose

The two main issues outlined in the docs regarding loose mode are that
loose mode class methods are enumerable and there is an edge case where
extending a class that has a setter with the same name as an instance
method, the setter will be triggered.