### PR TITLE
Default jscript option to use explorer target versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,3 @@ Default options can be overridden using the `removePropTypes` option. These opti
 ```
 
 For example, if you are using this plugin in a deployable app, you might want to use the remove mode for your production build (and disable this transform entirely in development for optimal build speeds).
-
-## JScript
-
-This preset uses a transform to protect against JScript bugs in older versions of Internet Explorer. If you'd like to disable this, set the `jscript` option to `false`:
-
-```json
-{
-  "presets": [["airbnb", {
-    "jscript": false,
-  }]]
-}
-```

--- a/index.js
+++ b/index.js
@@ -24,8 +24,13 @@ module.exports = declare((api, options) => {
     modules,
     targets = buildTargets(options),
     removePropTypes,
-    jscript = true,
   } = options;
+
+  // jscript option is deprecated in favor of using the explorer target version
+  // TODO: remove this option entirely in the next major release.
+  const jscript = Object.prototype.hasOwnProperty.call(options, 'jscript')
+    ? options.jscript
+    : (targets.explorer >= 6 && targets.explorer <= 8);
 
   if (typeof modules !== 'undefined' && typeof modules !== 'boolean' && modules !== 'auto') {
     throw new TypeError('babel-preset-airbnb only accepts `true`, `false`, or `"auto"` as the value of the "modules" option');


### PR DESCRIPTION
Instead of providing an explicit option for disabling this
transformation, we can make this automatic by using the target browser
versions that are affected by providing this transformation.

I didn't remove the option entirely yet because that would be a breaking
change, so I left it in but removed the documentation. We can remove it
in the next major version.