### PR TITLE
Change explorer => ie and remove ucandroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You may override our default list of targets by providing your own `targets` key
   "presets": [["airbnb", {
     "targets": {
       "chrome": 50,
-      "explorer": 11,
+      "ie": 11,
       "firefox": 45
     }
   }]]
@@ -81,7 +81,7 @@ If you wish, you can also inherit our default list of browsers and extend them u
   "presets": [["airbnb", {
     "additionalTargets": {
       "chrome": 42,
-      "explorer": 8
+      "ie": 8
     }
   }]]
 }

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ module.exports = declare((api, options) => {
     looseClasses = false,
   } = options;
 
-  // jscript option is deprecated in favor of using the explorer target version
+  // jscript option is deprecated in favor of using the ie target version
   // TODO: remove this option entirely in the next major release.
   const jscript = Object.prototype.hasOwnProperty.call(options, 'jscript')
     ? options.jscript
-    : (targets.explorer >= 6 && targets.explorer <= 8);
+    : (targets.ie >= 6 && targets.ie <= 8);
 
   if (typeof modules !== 'undefined' && typeof modules !== 'boolean' && modules !== 'auto') {
     throw new TypeError('babel-preset-airbnb only accepts `true`, `false`, or `"auto"` as the value of the "modules" option');

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const defaultTargets = {
   android: 30,
   chrome: 35,
   edge: 14,
-  explorer: 9,
+  ie: 9,
   firefox: 52,
   safari: 8,
   ucandroid: 1,

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const defaultTargets = {
   ie: 9,
   firefox: 52,
   safari: 8,
-  ucandroid: 1,
 };
 
 function buildTargets({ additionalTargets }) {


### PR DESCRIPTION
Seems our target name for internet explorer is out of sync:

https://github.com/babel/babel/blob/3856bc34d73b87520cf70d3cf2f64bc81cf8629f/packages/babel-preset-env/src/options.js#L44

@lencioni 