### PR TITLE
Use @babel/plugin-transform-runtime for helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,13 @@ module.exports = declare((api, options) => {
       [require('@babel/plugin-proposal-object-rest-spread'), {
         useBuiltIns: true,
       }],
+      [require('@babel/plugin-transform-runtime'), {
+        absoluteRuntime: false,
+        corejs: false,
+        helpers: true,
+        regenerator: false,
+        useESModules: !modules,
+      }],
     ].filter(Boolean),
   };
 });

--- a/package.json
+++ b/package.json
@@ -24,16 +24,19 @@
     "@babel/plugin-transform-member-expression-literals": "^7.0.0",
     "@babel/plugin-transform-property-literals": "^7.0.0",
     "@babel/plugin-transform-property-mutators": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.18"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.0.0",
+    "@babel/runtime": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
     "eslint": "^5.6.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
By default, a bunch of babel helpers end up being inlined into each
module as needed. With Babel 7, we can use
@babel/plugin-transform-runtime to add imports for @babel/runtime
modules instead of inlining and duplicating these helper functions. This
should reduce bundle sizes of projects using this preset.

Here is an example diff of one module with this change:

```diff
0a1,4
> import _extends from "@babel/runtime/helpers/esm/extends";
> import _assertThisInitialized from "@babel/runtime/helpers/esm/assertThisInitialized";
> import _inheritsLoose from "@babel/runtime/helpers/esm/inheritsLoose";
> import _objectSpread from "@babel/runtime/helpers/esm/objectSpread";
2,12d5
<
< function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
<
< function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
<
< function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
<
< function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
<
< function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
<
```