### PR TITLE
Use esm runtime helpers only when `modules === false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ module.exports = declare((api, options) => {
     throw new TypeError('babel-preset-airbnb only accepts `true`, `false`, or `"auto"` as the value of the "modules" option');
   }
 
+  const computedModulesOption = modules === false ? false : 'auto';
+
   const debug = typeof options.debug === 'boolean' ? options.debug : false;
   const development = typeof options.development === 'boolean'
     ? options.development
@@ -50,7 +52,7 @@ module.exports = declare((api, options) => {
           'transform-template-literals',
           'transform-regenerator',
         ],
-        modules: modules === false ? false : 'auto',
+        modules: computedModulesOption,
         targets,
       }],
       [require('@babel/preset-react'), { development }],
@@ -81,7 +83,7 @@ module.exports = declare((api, options) => {
         corejs: false,
         helpers: true,
         regenerator: false,
-        useESModules: !modules,
+        useESModules: !computedModulesOption,
       }],
     ].filter(Boolean),
   };


### PR DESCRIPTION
When `modules` is not specified, it is falsey, but we actually default
it to `'auto'` before passing it to preset-env. The mistake here made
it so the esm helpers are always used.