### PR TITLE
Add plugins to transpile TypeScript 3.7 features

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,8 @@ module.exports = declare((api, options) => {
       require('@babel/plugin-transform-property-mutators'),
       require('@babel/plugin-transform-member-expression-literals'),
       require('@babel/plugin-transform-property-literals'),
+      require('@babel/plugin-proposal-nullish-coalescing-operator'),
+      require('@babel/plugin-proposal-optional-chaining'),
       jscript ? require('@babel/plugin-transform-jscript') : null,
       [require('@babel/plugin-proposal-object-rest-spread'), {
         useBuiltIns: true,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "license": "MIT",
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/plugin-transform-classes": "^7.4.4",
     "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
     "@babel/plugin-transform-jscript": "^7.2.0",


### PR DESCRIPTION
TypeScript 3.7 comes with two new features that need to be transpiled via Babel before use.