### PR TITLE
Separate modules and useESModules options

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,29 @@ ex. If package.json has `"@babel/runtime": "^7.5.5"` then you can use:
 ```
 
 Note that this will result in a runtime breakage if the version passed into the airbnb preset is newer than the version of the babel runtime actually being used at build time.
+
+## Specifying module transforms
+
+You can use the `modules` option to enable transformation of modules given to this preset:
+
+```json
+{
+  "presets": [["airbnb", {
+    "modules": "auto"
+  }]]
+}
+```
+
+Both `true` and the option default `auto` will not transform modules if ES6 module syntax is already supported by the environment, or `"commonjs"` otherwise. `false` will not transform modules.
+
+You can use the `useESModules` option to prevent transformation of runtime helpers to CommonJS modules.
+
+```json
+{
+  "presets": [["airbnb", {
+    "useESModules": true
+  }]]
+}
+```
+
+`true` will not transform runtime helpers to CommonJS modules. The option default `false` will transform runtime helpers to CommonJS modules.

--- a/README.md
+++ b/README.md
@@ -196,14 +196,14 @@ You can use the `modules` option to enable transformation of modules given to th
 
 Both `true` and the option default `auto` will not transform modules if ES6 module syntax is already supported by the environment, or `"commonjs"` otherwise. `false` will not transform modules.
 
-You can use the `useESModules` option to prevent transformation of runtime helpers to CommonJS modules.
+You can use the `runtimeHelpersUseESModules` option to prevent transformation of runtime helpers to CommonJS modules.
 
 ```json
 {
   "presets": [["airbnb", {
-    "useESModules": true
+    "runtimeHelpersUseESModules": true
   }]]
 }
 ```
 
-`true` will not transform runtime helpers to CommonJS modules. The option default `false` will transform runtime helpers to CommonJS modules.
+`true` will not transform runtime helpers to CommonJS modules. `false` will transform runtime helpers to CommonJS modules. The option defaults to `true` if `modules` is set to `false`, and `false` otherwise.

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = declare((api, options) => {
     removePropTypes,
     looseClasses = false,
     runtimeVersion,
+    useESModules = false,
   } = options;
 
   // jscript option is deprecated in favor of using the ie target version
@@ -36,8 +37,6 @@ module.exports = declare((api, options) => {
   if (typeof modules !== 'undefined' && typeof modules !== 'boolean' && modules !== 'auto') {
     throw new TypeError('babel-preset-airbnb only accepts `true`, `false`, or `"auto"` as the value of the "modules" option');
   }
-
-  const computedModulesOption = modules === false ? false : 'auto';
 
   const debug = typeof options.debug === 'boolean' ? options.debug : false;
   const development = typeof options.development === 'boolean'
@@ -53,7 +52,7 @@ module.exports = declare((api, options) => {
           'transform-template-literals',
           'transform-regenerator',
         ],
-        modules: computedModulesOption,
+        modules: modules === false ? false : 'auto',
         targets,
       }],
       [require('@babel/preset-react'), { development }],
@@ -86,7 +85,7 @@ module.exports = declare((api, options) => {
         corejs: false,
         helpers: true,
         regenerator: false,
-        useESModules: !computedModulesOption,
+        useESModules,
         version: runtimeVersion,
       }],
     ].filter(Boolean),

--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@ module.exports = declare((api, options) => {
   api.assertVersion('^7.0.0');
 
   const {
-    modules,
+    modules = 'auto',
     targets = buildTargets(options),
     removePropTypes,
     looseClasses = false,
     runtimeVersion,
-    useESModules = false,
+    useESModules = !modules,
   } = options;
 
   // jscript option is deprecated in favor of using the ie target version
@@ -34,7 +34,7 @@ module.exports = declare((api, options) => {
     ? options.jscript
     : (targets.ie >= 6 && targets.ie <= 8);
 
-  if (typeof modules !== 'undefined' && typeof modules !== 'boolean' && modules !== 'auto') {
+  if (typeof modules !== 'boolean' && modules !== 'auto') {
     throw new TypeError('babel-preset-airbnb only accepts `true`, `false`, or `"auto"` as the value of the "modules" option');
   }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = declare((api, options) => {
     removePropTypes,
     looseClasses = false,
     runtimeVersion,
-    useESModules = !modules,
+    runtimeHelpersUseESModules = !modules,
   } = options;
 
   // jscript option is deprecated in favor of using the ie target version
@@ -85,7 +85,7 @@ module.exports = declare((api, options) => {
         corejs: false,
         helpers: true,
         regenerator: false,
-        useESModules,
+        useESModules: runtimeHelpersUseESModules,
         version: runtimeVersion,
       }],
     ].filter(Boolean),


### PR DESCRIPTION
In a scenario where a consumer wishes to use this preset but also expects the output to be built as CommonJS modules (by using the `@babel/plugin-transform-modules-commonjs` plugin), this preset will actually output invalid code if `modules: false` is specified.

[Babel runs plugins before presets](https://babeljs.io/docs/en/plugins/#plugin-ordering), so the `@babel/plugin-transform-modules-commonjs` plugin will not be able to convert the ESModules created by `@babel/plugin-transform-runtime`.

I think we can fix this by breaking out the `modules` option from the `useESModules` option. That way this preset can avoid modifying the type of modules given to it, and developers can specify the type of runtime modules that will be included in the output.