### PR TITLE
Add option to disable plugin-transform-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Note that this will result in a runtime breakage if the version passed into the 
 
 ## Disabling `plugin-transform-runtime`
 
-You can use the `transformRuntime` option to disable [`@babel/plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime). Specifying `false` will disable the plugin.
+You can use the `transformRuntime` option to disable [`@babel/plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime). Specifying `false` will disable the plugin. This option defaults to `true`.
 
 ## Specifying module transforms
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ ex. If package.json has `"@babel/runtime": "^7.5.5"` then you can use:
 
 Note that this will result in a runtime breakage if the version passed into the airbnb preset is newer than the version of the babel runtime actually being used at build time.
 
+## Disabling `plugin-transform-runtime`
+
+You can use the `transformRuntime` option to disable [`@babel/plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime). Specifying `false` will disable the plugin.
+
 ## Specifying module transforms
 
 You can use the `modules` option to enable transformation of modules given to this preset:

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = declare((api, options) => {
     looseClasses = false,
     runtimeVersion,
     runtimeHelpersUseESModules = !modules,
+    transformRuntime = true,
   } = options;
 
   // jscript option is deprecated in favor of using the ie target version
@@ -80,14 +81,14 @@ module.exports = declare((api, options) => {
       [require('@babel/plugin-proposal-object-rest-spread'), {
         useBuiltIns: true,
       }],
-      [require('@babel/plugin-transform-runtime'), {
+      transformRuntime ? [require('@babel/plugin-transform-runtime'), {
         absoluteRuntime: false,
         corejs: false,
         helpers: true,
         regenerator: false,
         useESModules: runtimeHelpersUseESModules,
         version: runtimeVersion,
-      }],
+      }] : null,
     ].filter(Boolean),
   };
 });


### PR DESCRIPTION
Allowing `plugin-transform-runtime` with `helpers: true` adds references to helper modules that can cause issues with certain bundlers, including Metro, that prepend scripts to enable custom `require`s.