### PR TITLE
add @babel/plugin-transform-destructuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.9.0",
     "@babel/plugin-transform-classes": "^7.9.2",
+    "@babel/plugin-transform-destructuring": "^7.17.7",
     "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
     "@babel/plugin-transform-member-expression-literals": "^7.8.3",
     "@babel/plugin-transform-property-literals": "^7.8.3",


### PR DESCRIPTION
since some other projects that use babel-preset-airbnb also have tests for older version of node.js like v4 and v5, plugin-transform-destructuring is needed